### PR TITLE
Really fix application.yml ISSUE_TEMPLATE: add space in type declaration

### DIFF
--- a/.github/ISSUE_TEMPLATE/application.yml
+++ b/.github/ISSUE_TEMPLATE/application.yml
@@ -100,7 +100,7 @@ body:
     placeholder: Add maintainer URL here
   validations:
     required: true
--type: checkboxes
+- type: checkboxes
   id: terms
   attributes:
     label: IP Policy
@@ -108,7 +108,7 @@ body:
     options:
       - label: If the project is accepted, I agree the project will follow the CNCF IP Policy
         required: true
--type: checkboxes
+- type: checkboxes
   id: terms
   attributes:
     label: Trademark and accounts


### PR DESCRIPTION
There was a space still missing in the application type declaration.

Not sure how to test this but I think this should do it this time.

fixes #2 

Signed-off-by: Chris Kühl <chriskuehl@microsoft.com>