### PR TITLE
Fix missing type in application.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/application.yml
+++ b/.github/ISSUE_TEMPLATE/application.yml
@@ -116,6 +116,7 @@ body:
     options:
       - label: If the project is accepted, I agree to donate all project trademarks and accounts to the CNCF
         required: true
+- type: textarea
   attributes:
     label: Why CNCF?
     description:  Why do you want to contribute the project to the CNCF? What value does being part of the CNCF provide the project?


### PR DESCRIPTION
The "Why CNCF?" textarea didn't have its type, and this was causing validation errors.

Signed-off-by: Dave Zolotusky <dzolo@spotify.com>