### PR TITLE
Update GitVote config

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,7 +1,8 @@
 # Example file: https://github.com/cncf/gitvote/blob/main/docs/config/.gitvote.yml
-default:
-  duration: 13w
-  pass_threshold: 66
-  allowed_voters:
-    teams: 
-      - toc
+profiles:
+  default:
+    duration: 13w
+    pass_threshold: 66
+    allowed_voters:
+      teams:
+        - toc


### PR DESCRIPTION
We've introduced some breaking changes in the GitVote configuration file to make room for a new feature ([automatic vote creation on PRs](https://github.com/cncf/gitvote/pull/182)). The latest GitVote version we've just deployed is expecting the new format, so it'd be great if you could merge this as soon as possible.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>