### PR TITLE
What: Update application template with correct link

### DIFF
--- a/.github/ISSUE_TEMPLATE/application.yml
+++ b/.github/ISSUE_TEMPLATE/application.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: |
-     Thanks for filling out a sandbox application. Please read the Sandbox guidelines and understand what the sandbox is along with the [minimal support and marketing expectations](https://github.com/cncf/toc/blob/main/process/sandbox.md#clarifying-marketing-expectations) for sandbox projects.
+     Thanks for filling out a sandbox application. Please read the Sandbox guidelines and understand what the sandbox is along with the [minimal support and marketing expectations](https://contribute.cncf.io/resources/project-services/maturity-levels/#sandbox) for sandbox projects.
 - type: textarea
   attributes:
     label: Application contact emails


### PR DESCRIPTION
Why:
 * repo changes resulted in content loss

This change address the need by:
 * changing line 9 of the template to reflect https://contribute.cncf.io/resources/project-services/maturity-levels/#sandbox