### PR TITLE
correct onboarding link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ The TOC reviews and discusses Isobars. The TOC determines that Isobars is a *ver
 
 ## Acceptance
 
-Once projects are accepted into the Sandbox, CNCF staff will open a project onboarding issue for the project based on [project onboarding template](https://github.com/cncf/toc/blob/main/.github/ISSUE_TEMPLATE/project-onboarding.md) - this may take a few days to get created. If you would like to start looking at the items on that list now, then you will be ready when for when the issue is opened. 
+Once projects are accepted into the Sandbox, CNCF staff will open a project onboarding issue for the project based on [project onboarding template](https://github.com/cncf/sandbox/blob/main/.github/ISSUE_TEMPLATE/project-onboarding.md) - this may take a few days to get created. If you would like to start looking at the items on that list now, then you will be ready when for when the issue is opened. 


### PR DESCRIPTION
small fix I missed when adding the template. Corrects the link to point to the right place