### PR TITLE
Update onboarding issue template for new trademark process (#910).

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -16,10 +16,11 @@ Please track your progress by using "Quote reply" to create your own copy of thi
 
 ## REQUIRED BEFORE PROCEEDING WITH ONBOARDING
 
-Any existing trademarks **MUST** be transferred to the Linux Foundation **BEFORE** further project onboarding tasks can be completed.
+A "Project Contribution Agreement" must be completed and any existing trademarks **MUST** be transferred to the Linux Foundation **BEFORE** further project onboarding tasks can be completed.
 
+- [ ] The [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy).
 - [ ] Review and understand the [trademark guidelines](https://www.linuxfoundation.org/legal/trademark-usage).
-- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements).
+- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements) via the Contribution Agreement.
 
 ---
 
@@ -28,7 +29,6 @@ Any existing trademarks **MUST** be transferred to the Linux Foundation **BEFORE
 - [ ] The [Technical Leadership Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md#technical-leadership-principles) that outlines the expected behavior for any maintainer in a leadership role.
 - [ ] The [project proposal process and requirements](https://github.com/cncf/toc/blob/main/process/README.md).
 - [ ] The [services available for your project at the CNCF](https://contribute.cncf.io/resources/project-services/).
-- [ ] The [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy).
 - [ ] The [license allowlist](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
 - [ ] The [online program guidelines](https://github.com/cncf/foundation/blob/main/online-programs-guidelines.md).
 - [ ] [Book time with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources.

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -31,6 +31,7 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 - [ ] The [services available for your project at the CNCF](https://contribute.cncf.io/resources/project-services/).
 - [ ] The [license allowlist](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
 - [ ] The [online program guidelines](https://github.com/cncf/foundation/blob/main/online-programs-guidelines.md).
+- [ ] The [telemetry data collection and usage policy](https://www.linuxfoundation.org/legal/telemetry-data-policy).
 - [ ] [Book time with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources.
 
 ## Contribute and transfer other materials

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -19,8 +19,8 @@ Please track your progress by using "Quote reply" to create your own copy of thi
 A "Project Contribution Agreement" must be completed and any existing trademarks **MUST** be transferred to the Linux Foundation **BEFORE** further project onboarding tasks can be completed.
 
 - [ ] Review and understand the [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy).
-- [ ] Review and understand the [trademark guidelines](https://www.linuxfoundation.org/legal/trademark-usage).
-- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements) via the Contribution Agreement.
+- [ ] Review and understand the [LF trademark guidelines](https://www.linuxfoundation.org/legal/trademark-usage).
+- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements) via the Contribution Agreement. CNCF staff will send this to the contact emails listed in the Sandbox application.
 
 ---
 
@@ -47,7 +47,7 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 
 - [ ] Ensure that [DCO](https://github.com/apps/dco) (preferred) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project.
 - [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's `README.md` on GitHub.
-- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md) are followed (if your project doesn't have a dedicated website, please adopt those guidelines for the `README.md` file).
+- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md) are followed (if your project doesn't have a dedicated website, please adopt those guidelines for the `README.md` file). The project-specific footer text you should use will be provided in the Contribution Agreement instructions.
 - [ ] Create a maintainer list and add it to the [aggregated CNCF maintainer list](https://maintainers.cncf.io) via pull request.
 - [ ] Provide emails for the maintainers to get access to the maintainers mailing list and Service Desk. Email them to <project-onboarding@cncf.io>.
 - [ ] Start working on [written, open governance](https://contribute.cncf.io/maintainers/governance/) and consider adding this to a `GOVERNANCE.md` file at the root of your repo.

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -18,13 +18,13 @@ Please track your progress by using "Quote reply" to create your own copy of thi
 
 A "Project Contribution Agreement" must be completed and any existing trademarks **MUST** be transferred to the Linux Foundation **BEFORE** further project onboarding tasks can be completed.
 
-- [ ] The [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy).
+- [ ] Review and understand the [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy).
 - [ ] Review and understand the [trademark guidelines](https://www.linuxfoundation.org/legal/trademark-usage).
 - [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements) via the Contribution Agreement.
 
 ---
 
-## Review and understand
+## Review and understand other documents
 
 - [ ] The [Technical Leadership Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md#technical-leadership-principles) that outlines the expected behavior for any maintainer in a leadership role.
 - [ ] The [project proposal process and requirements](https://github.com/cncf/toc/blob/main/process/README.md).
@@ -33,7 +33,7 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 - [ ] The [online program guidelines](https://github.com/cncf/foundation/blob/main/online-programs-guidelines.md).
 - [ ] [Book time with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources.
 
-## Contribute and transfer
+## Contribute and transfer other materials
 
 - [ ] Move your project to its own separate neutral GitHub organization. This will make it transferable to the CNCF's GitHub Enterprise account. If it's already in a GHE account, you will need to remove it from that first.
 - [ ] Accept the invite to join the CNCF GitHub Enterprise account. We'll then add `thelinuxfoundation` as an organization owner to ensure neutral hosting of your project.
@@ -43,7 +43,7 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 - [ ] Submit a [pull request](https://github.com/cncf/artwork) with your artwork.
 - [ ] Transfer website analytics to <projects@cncf.io>. CNCF staff can help.
 
-## Update and document
+## Update and document project details
 
 - [ ] Ensure that [DCO](https://github.com/apps/dco) (preferred) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project.
 - [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's `README` on GitHub.
@@ -53,7 +53,7 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 - [ ] Start working on [written, open governance](https://contribute.cncf.io/maintainers/governance/).
 - [ ] Start on an [OpenSSF Best Practices Badge](https://www.bestpractices.dev/en).
 
-## CNCF staff tasks
+## CNCF staff tasks to support the project
 
 - [ ] Add the project to [DevStats](https://devstats.cncf.io/).
 - [ ] Add the project to [CLOmonitor](https://clomonitor.io/).

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -46,11 +46,11 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 ## Update and document project details
 
 - [ ] Ensure that [DCO](https://github.com/apps/dco) (preferred) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project.
-- [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's `README` on GitHub.
-- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md) are followed (if your project doesn't have a dedicated website, please adopt those guidelines for the `README` file).
+- [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's `README.md` on GitHub.
+- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md) are followed (if your project doesn't have a dedicated website, please adopt those guidelines for the `README.md` file).
 - [ ] Create a maintainer list and add it to the [aggregated CNCF maintainer list](https://maintainers.cncf.io) via pull request.
 - [ ] Provide emails for the maintainers to get access to the maintainers mailing list and Service Desk. Email them to <project-onboarding@cncf.io>.
-- [ ] Start working on [written, open governance](https://contribute.cncf.io/maintainers/governance/).
+- [ ] Start working on [written, open governance](https://contribute.cncf.io/maintainers/governance/) and consider adding this to a `GOVERNANCE.md` file at the root of your repo.
 - [ ] Start on an [OpenSSF Best Practices Badge](https://www.bestpractices.dev/en).
 
 ## CNCF staff tasks to support the project

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -18,9 +18,9 @@ Please track your progress by using "Quote reply" to create your own copy of thi
 
 A "Project Contribution Agreement" must be completed and any existing trademarks **MUST** be transferred to the Linux Foundation **BEFORE** further project onboarding tasks can be completed.
 
-- [ ] Review and understand the [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy).
+- [ ] Review and understand the [CNCF IP Policy](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy). Ensure you are using a CNCF compatible license; inbound projects must use the Apache 2.0 license or seek approval for exceptions. Licenses for dependencies are covered separately below.
 - [ ] Review and understand the [LF trademark guidelines](https://www.linuxfoundation.org/legal/trademark-usage).
-- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements) via the Contribution Agreement. CNCF staff will send this to the contact emails listed in the Sandbox application.
+- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/main/agreements) via the Contribution Agreement. CNCF staff will send this document to the contact emails listed in the Sandbox application.
 
 ---
 
@@ -29,7 +29,7 @@ A "Project Contribution Agreement" must be completed and any existing trademarks
 - [ ] The [Technical Leadership Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md#technical-leadership-principles) that outlines the expected behavior for any maintainer in a leadership role.
 - [ ] The [project proposal process and requirements](https://github.com/cncf/toc/blob/main/process/README.md).
 - [ ] The [services available for your project at the CNCF](https://contribute.cncf.io/resources/project-services/).
-- [ ] The [license allowlist](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
+- [ ] The [dependency license allowlist](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
 - [ ] The [online program guidelines](https://github.com/cncf/foundation/blob/main/online-programs-guidelines.md).
 - [ ] The [telemetry data collection and usage policy](https://www.linuxfoundation.org/legal/telemetry-data-policy).
 - [ ] [Book time with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources.


### PR DESCRIPTION
* Related to https://github.com/cncf/foundation/issues/910
* Update template to set Project Contribution Agreement / trademark transfer as key step before other tasks can be done.
* Reword other sections for additional clarity.
* Since the CA refers to governance, suggesting it's documented in a `GOVERNANCE.md` file.
* Add LF telemetry policy.