### PR TITLE
Update the description for Business/Project Separation question.

### DIFF
--- a/.github/ISSUE_TEMPLATE/application.yml
+++ b/.github/ISSUE_TEMPLATE/application.yml
@@ -168,7 +168,7 @@ body:
 - type: textarea
   attributes:
     label: Business Product or Service to Project separation
-    description: If this project is related to one or more products or services of the sponsoring company/organization(s), please explain how you plan to separate this project from any products in terms or organization and development.  The project could be the "upstream" open source version of a product or service, be a required dependency, or be a key part of the infrastructure you use to develop your products/services.  If the project is completely unrelated to any product/service, please put "This project is unrelated to any product."
+    description: If this project is related to one or more products or services of the sponsoring company/organization(s), please explain how you plan to separate this project from any products in terms of organization and development.  The project could be the "upstream" open source version of a product or service, be a required dependency, or be a key part of the infrastructure you use to develop your products/services.  If the project is completely unrelated to any product/service, or the project contributor is not a business, please put "This project is unrelated to any product or service."
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/application.yml
+++ b/.github/ISSUE_TEMPLATE/application.yml
@@ -168,7 +168,7 @@ body:
 - type: textarea
   attributes:
     label: Business Product or Service to Project separation
-    description: If this project is identical (name, features, etc.) or closely related to one or more products or services of the sponsoring company/organization(s), how do you plan to separate this project from any products in terms of organization and development? If it is not related to a product or service, just provide "N/A".
+    description: If this project is related to one or more products or services of the sponsoring company/organization(s), please explain how you plan to separate this project from any products in terms or organization and development.  The project could be the "upstream" open source version of a product or service, be a required dependency, or be a key part of the infrastructure you use to develop your products/services.  If the project is completely unrelated to any product/service, please put "This project is unrelated to any product."
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Change the description of "Business product or service and project separation" to make it more inclusive.  The current template has resulted in a lot of organizations submitting projects that are quite clearly part of their products and putting N/A.  