### PR TITLE
Update gitvote voters to cncf-toc-voters

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -5,7 +5,7 @@ profiles:
     pass_threshold: 66
     allowed_voters:
       teams:
-        - cncf-toc
+        - cncf-toc-voters
       exclude_team_maintainers: true
     close_on_passing: true
   sandbox:
@@ -13,6 +13,6 @@ profiles:
     pass_threshold: 66
     allowed_voters:
       teams:
-        - cncf-toc
+        - cncf-toc-voters
       exclude_team_maintainers: true
     close_on_passing: true


### PR DESCRIPTION
Changes the voter group to cncf-toc-voters
As the shadows are included in the cncf-toc group it should no longer be used for voting.