### PR TITLE
Add CA checkpoint to Vote Monitor before creating onboarding issue

### DIFF
--- a/.github/workflows/vote-monitor.yml
+++ b/.github/workflows/vote-monitor.yml
@@ -55,9 +55,9 @@ jobs:
                 const projectName = sandboxMatch[1].trim();
                 console.log(`📝 Processing issue #${issue.number}: "${projectName}"`);
                 
-                const hasUnsignedCLA = (issue.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'contribution-agreement/unsigned');
+                const hasUnsignedCA = (issue.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'contribution-agreement/unsigned');
 
-                if (hasUnsignedCLA) {
+                if (hasUnsignedCA) {
                   console.log(`⏸️  Issue #${issue.number} has contribution-agreement/unsigned; posting CA reminder and skipping onboarding creation.`);
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
@@ -85,7 +85,7 @@ jobs:
               const labels = issue.labels || [];
               const labelNames = labels.map(l => (typeof l === 'string' ? l : l.name));
               const hasVotePassed = labelNames.includes('gitvote/passed');
-              const hasUnsignedCLA = labelNames.includes('contribution-agreement/unsigned');
+              const hasUnsignedCA = labelNames.includes('contribution-agreement/unsigned');
 
               if (!hasVotePassed) {
                 console.log('ℹ️  Skipping: issue does not have gitvote/passed label.');
@@ -101,7 +101,7 @@ jobs:
               }
               const projectName = sandboxMatch[1].trim();
 
-              if (hasUnsignedCLA) {
+              if (hasUnsignedCA) {
                 console.log('⏸️  CA unsigned label present; posting reminder and not creating onboarding.');
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,


### PR DESCRIPTION
### Summary
Introduces a CLA gate in the `vote-monitor.yml` workflow:
- If an issue has `gitvote/passed` and `contribution-agreement/unsigned`, post a Contributor Agreement reminder comment and skip onboarding creation.
- Once `contribution-agreement/unsigned` is removed (and `gitvote/passed` remains), proceed with the normal onboarding flow.
- Supports both automatic label events and manual runs.

### What’s changed
- Triggers on `issues` events for both `labeled` and `unlabeled`.
- On label add/remove:
  - Require `gitvote/passed` and a `[Sandbox] ...` title.
  - If `contribution-agreement/unsigned` is present: post reminder and do not create onboarding.
  - Otherwise: create onboarding and close the original via existing helpers.
- Manual run (`workflow_dispatch`):
  - Scans open issues with `gitvote/passed`.
  - Applies the same Contributor Agreement check and either posts reminder or proceeds with onboarding.
- Input default fixed to boolean (`default: false`).

### User-visible behavior
- When CLA is unsigned:
  - Comment is posted: “The TOC vote for ${projectName} has passed! 🎉 Next step: Please finalize the Contributor Agreement . This is required before official CNCF on-boarding can begin. Please reach out to CNCF Staff for assistance.”
  - Onboarding issue is not created.
- When CLA label is removed:
  - Workflow proceeds to create the onboarding issue and comments/closes the original.

### Files
- `/.github/workflows/vote-monitor.yml`: updated logic and triggers.